### PR TITLE
Support Seq and List decoding

### DIFF
--- a/core/src/main/scala/cats/xml/xmlNode.scala
+++ b/core/src/main/scala/cats/xml/xmlNode.scala
@@ -262,7 +262,7 @@ object XmlNode extends XmlNodeInstances with XmlNodeSyntax {
     elements.toList match {
       case Nil           => XmlNode.emptyGroup
       case ::(head, Nil) => head
-      case all           => new Group(NodeContent.childrenOrEmpty(all))
+      case all           => new Group(NodeContent.children(all))
     }
 
   /** Create a new [[XmlNode.Group]] instance with the specified [[XmlNode]]s
@@ -284,7 +284,7 @@ object XmlNode extends XmlNodeInstances with XmlNodeSyntax {
     *   A new [[XmlNode.Group]] instance with the specified [[XmlNode]]s
     */
   def group(elements: Seq[XmlNode]): XmlNode.Group =
-    new Group(NodeContent.childrenOrEmpty(elements))
+    new Group(NodeContent.children(elements))
 
   // --------------------- XML NODE ---------------------
   /** Represent a simple single XML node.
@@ -543,7 +543,7 @@ sealed trait XmlNodeSyntax {
       withChildren(child +: children)
 
     def withChildren(children: Seq[XmlNode]): Self =
-      withContent(NodeContent.children(children).getOrElse(NodeContent.empty))
+      withContent(NodeContent.children(children))
 
     def appendChildren(child: XmlNode, children: XmlNode*): Self =
       updateChildren(currentChildren => currentChildren ++ List(child) ++ children)
@@ -614,7 +614,7 @@ sealed trait XmlNodeSyntax {
     /** Set node content to Text with the specified data. All children nodes will be removed.
       */
     def withText[T: DataEncoder](data: T): XmlNode.Node =
-      node.withContent(NodeContent.textOrEmpty(data))
+      node.withContent(NodeContent.text(data))
 
     /** Decode and then update node text if content is text.
       *

--- a/core/src/test/scala/cats/xml/NodeContentSuite.scala
+++ b/core/src/test/scala/cats/xml/NodeContentSuite.scala
@@ -17,13 +17,13 @@ class NodeContentSuite extends munit.ScalaCheckSuite {
 
   test("NodeContent.text('FOO') is NOT empty") {
     assert(
-      NodeContent.textOrEmpty("FOO").nonEmpty
+      NodeContent.text("FOO").nonEmpty
     )
   }
 
   test("NodeContent.text('') is empty") {
     assert(
-      NodeContent.textOrEmpty("").isEmpty
+      NodeContent.text("").isEmpty
     )
   }
 
@@ -48,7 +48,7 @@ class NodeContentSuite extends munit.ScalaCheckSuite {
     property(s"NodeContent.text create content with ${c.runtimeClass.getSimpleName}") {
       forAll { (value: T) =>
         assertEquals(
-          obtained = NodeContent.textOrEmpty(value).text.flatMap(_.as[T].toOption),
+          obtained = NodeContent.text(value).text.flatMap(_.as[T].toOption),
           expected = if (DataEncoder[T].encode(value).isEmpty) None else Some(value)
         )
       }

--- a/core/src/test/scala/cats/xml/XmlNodeSuite.scala
+++ b/core/src/test/scala/cats/xml/XmlNodeSuite.scala
@@ -48,7 +48,7 @@ class XmlNodeSuite extends munit.FunSuite {
 
   test("XmlNode.apply") {
     assertEquals(
-      obtained = XmlNode("Foo", List("A" := 1), NodeContent.textOrEmpty("Text")),
+      obtained = XmlNode("Foo", List("A" := 1), NodeContent.text("Text")),
       expected = XmlNode("Foo").withAttributes("A" := 1).withText("Text")
     )
     intercept[IllegalArgumentException](

--- a/core/src/test/scala/cats/xml/codec/DecoderSeqSuite.scala
+++ b/core/src/test/scala/cats/xml/codec/DecoderSeqSuite.scala
@@ -1,0 +1,114 @@
+package cats.xml.codec
+
+import cats.data.Validated.Valid
+import cats.implicits.{catsSyntaxOptionId, catsSyntaxTuple2Semigroupal}
+import cats.xml.XmlNode
+import cats.xml.syntax.DecoderOps
+
+// TODO: Move to decoder suite
+class DecoderSeqSuite extends munit.FunSuite {
+
+  case class Baz(v: String)
+  object Baz {
+    implicit val bazD: Decoder[Baz] =
+      Decoder.fromCursor(_.text.as[String]).map(Baz(_))
+  }
+
+  case class Qux(v: String)
+  object Qux {
+    implicit val quxD: Decoder[Qux] =
+      Decoder.fromCursor(_.text.as[String]).map(Qux(_))
+
+  }
+
+  case class Bar(baz: Baz, qux: Option[Qux])
+  object Bar {
+    implicit val barD: Decoder[Bar] =
+      Decoder.fromCursor { c =>
+        (
+          c.down("baz").as[Baz],
+          c.down("qux").as[Option[Qux]]
+        ).mapN(Bar.apply)
+      }
+  }
+
+  case class Foo(bar: List[Bar])
+  object Foo {
+    implicit val fooD: Decoder[Foo] =
+      Decoder.fromCursor { c =>
+        c.down("bar")
+          .as[List[Bar]]
+          .map(Foo.apply)
+      }
+  }
+
+  test("Decoder[Seq[A]] with XmlNode") {
+
+    val data: XmlNode =
+      XmlNode("foo")
+        .withChildren(
+          XmlNode("bar")
+            .withChildren(
+              XmlNode("baz").withText("1")
+            ),
+          XmlNode("bar")
+            .withChildren(
+              XmlNode("baz").withText("2")
+            ),
+          XmlNode("bar")
+            .withChildren(
+              XmlNode("baz").withText("3"),
+              XmlNode("qux").withText("A")
+            )
+        )
+
+    assertEquals(
+      data.as[Foo],
+      Valid(
+        Foo(
+          List[Bar](
+            Bar(Baz("1"), None),
+            Bar(Baz("2"), None),
+            Bar(Baz("3"), Qux("A").some)
+          )
+        )
+      )
+    )
+  }
+
+  test("Decoder[Seq[A]] with XmlGroup") {
+
+    val data: XmlNode =
+      XmlNode("foo")
+        .withChildren(
+          XmlNode.group(
+            XmlNode("bar")
+              .withChildren(
+                XmlNode("baz").withText("1")
+              ),
+            XmlNode("bar")
+              .withChildren(
+                XmlNode("baz").withText("2")
+              ),
+            XmlNode("bar")
+              .withChildren(
+                XmlNode("baz").withText("3"),
+                XmlNode("qux").withText("A")
+              )
+          )
+        )
+
+    assertEquals(
+      data.as[Foo],
+      Valid(
+        Foo(
+          List[Bar](
+            Bar(Baz("1"), None),
+            Bar(Baz("2"), None),
+            Bar(Baz("3"), Qux("A").some)
+          )
+        )
+      )
+    )
+  }
+}

--- a/core/src/test/scala/cats/xml/cursor/NodeCursorSuite.scala
+++ b/core/src/test/scala/cats/xml/cursor/NodeCursorSuite.scala
@@ -47,15 +47,34 @@ class NodeCursorSuite extends munit.FunSuite {
     )
   }
 
-  test("NodeCursor.down with group") {
+  test("NodeCursor.down returns a group") {
 
-    val node: XmlNode = {
-
+    val node: XmlNode =
       XmlNode("Root").withChildren(
         XmlNode("Foo").withChildren(XmlNode("Value").withText(1)),
         XmlNode("Foo").withChildren(XmlNode("Value").withText(2))
       )
-    }
+
+    assertEquals(
+      obtained = Root.down("Foo").down("Value").focus(node),
+      expected = Right(
+        XmlNode.group(
+          XmlNode("Value").withText(1),
+          XmlNode("Value").withText(2)
+        )
+      )
+    )
+  }
+
+  test("NodeCursor.down with child group") {
+
+    val node: XmlNode =
+      XmlNode("Root").withChildren(
+        XmlNode.group(
+          XmlNode("Foo").withChildren(XmlNode("Value").withText(1)),
+          XmlNode("Foo").withChildren(XmlNode("Value").withText(2))
+        )
+      )
 
     assertEquals(
       obtained = Root.down("Foo").down("Value").focus(node),

--- a/core/src/test/scala/cats/xml/testing/XmlNodeGen.scala
+++ b/core/src/test/scala/cats/xml/testing/XmlNodeGen.scala
@@ -63,7 +63,7 @@ object XmlNodeGen {
     maxTextSize: Int      = 100
   ): Gen[XmlNode] = {
 
-    def genChildren: Gen[Option[NodeContent]] =
+    def genChildren: Gen[NodeContent] =
       if (maxDeep > 0)
         Gen.lzy(
           Gen
@@ -83,7 +83,7 @@ object XmlNodeGen {
             .map(NodeContent.children(_))
         )
       else
-        Gen.const(None)
+        Gen.const(NodeContent.empty)
 
     for {
       nodeName   <- Gen.lzy(getNonEmptyString(maxNodeName))
@@ -91,8 +91,8 @@ object XmlNodeGen {
       content <- Gen.lzy(
         Gen.frequency(
           2  -> Gen.const(NodeContent.empty),
-          18 -> Gen.lzy(getNonEmptyString(maxTextSize).map(NodeContent.textOrEmpty(_))),
-          80 -> Gen.lzy(genChildren.map(_.getOrElse(NodeContent.empty)))
+          18 -> Gen.lzy(getNonEmptyString(maxTextSize).map(NodeContent.text(_))),
+          80 -> Gen.lzy(genChildren)
         )
       )
     } yield XmlNode(nodeName)

--- a/modules/standard/src/main/scala/cats/xml/std/nodeSeqConverter.scala
+++ b/modules/standard/src/main/scala/cats/xml/std/nodeSeqConverter.scala
@@ -18,7 +18,7 @@ private[std] object NodeSeqConverter extends NodeSeqConverterInstances with Node
         XmlNode(
           label      = e.label,
           attributes = XmlAttribute.fromMetaData(e.attributes),
-          content    = NodeContent.textOrEmpty(e.text.trim)
+          content    = NodeContent.text(e.text.trim)
         )
       case e: Elem =>
         val tree = XmlNode(
@@ -36,7 +36,7 @@ private[std] object NodeSeqConverter extends NodeSeqConverterInstances with Node
         val content = if (neChildLen > 0) {
           val head = neChild.head
           if (head.isAtom) {
-            NodeContent.textOrEmpty(head.asInstanceOf[Atom[?]].data.toString.trim)
+            NodeContent.text(head.asInstanceOf[Atom[?]].data.toString.trim)
           } else {
 
             val res: Array[XmlNode] = new Array[XmlNode](neChildLen)
@@ -44,7 +44,7 @@ private[std] object NodeSeqConverter extends NodeSeqConverterInstances with Node
               res.update(idx, fromNodeSeq(neChild(idx)))
             }
 
-            NodeContent.children(res.toList).getOrElse(NodeContent.empty)
+            NodeContent.children(res.toList)
           }
 
         } else NodeContent.empty


### PR DESCRIPTION
Fix #137 in order to provide a proper `Decoder[Seq[T]]` and `Decoder[List[T]]` implementation. 

Moreover flat groups in order to support `Down` operator in nested cases 
