### PR TITLE
Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,7 +177,8 @@ lazy val baseSettings: Seq[Def.Setting[_]] = Seq(
 //  idePackagePrefix := Some(prjPackageName),
   // scala
   crossScalaVersions := supportedScalaVersions,
-  scalaVersion       := supportedScalaVersions.head,
+  scalaVersion       := scala33,
+//  scalaVersion       := supportedScalaVersions.head,
   scalacOptions ++= scalacSettings(scalaVersion.value),
   versionScheme := Some("early-semver"),
   // dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -177,8 +177,7 @@ lazy val baseSettings: Seq[Def.Setting[_]] = Seq(
 //  idePackagePrefix := Some(prjPackageName),
   // scala
   crossScalaVersions := supportedScalaVersions,
-  scalaVersion       := scala33,
-//  scalaVersion       := supportedScalaVersions.head,
+  scalaVersion       := supportedScalaVersions.head,
   scalacOptions ++= scalacSettings(scalaVersion.value),
   versionScheme := Some("early-semver"),
   // dependencies

--- a/internal-utils/src/main/scala-2/cats/xml/utils/generic/TypeInfoInstances.scala
+++ b/internal-utils/src/main/scala-2/cats/xml/utils/generic/TypeInfoInstances.scala
@@ -23,6 +23,7 @@ object TypeInfoInstances {
       val isPrimitiveWrapper: Boolean             = utils.isPrimitiveWrapper(wtpe)
       val isPrimitive: Boolean                    = utils.isPrimitive(wtpe)
       val isValueClass: Boolean                   = utils.isValueClass(wtpe)
+      val isNonPrimitiveValueClass: Boolean       = utils.isNonPrimitiveValueClass(wtpe)
       val isOptionOfAnyPrimitiveOrString: Boolean = utils.isOptionOfAnyPrimitiveOrString(wtpe)
       val accessorsInfo: c.Expr[Map[ParamName[T], TypeInfo[?]]] = deriveFieldsTypeInfoImpl[T](c)
 
@@ -38,7 +39,8 @@ object TypeInfoInstances {
             isPrimitive                      = $isPrimitive,
             isValueClass                     = $isValueClass,
             isOptionOfAnyPrimitiveOrString   = $isOptionOfAnyPrimitiveOrString,
-            accessorsInfo                    = $accessorsInfo
+            accessorsInfo                    = $accessorsInfo,
+            isNonPrimitiveValueClass         = $isNonPrimitiveValueClass
           )
          """
       )
@@ -104,6 +106,14 @@ object TypeInfoInstances {
           tpe.typeSymbol.isClass &&
           tpe.typeSymbol.asClass.isCaseClass &&
           getAccessors(tpe).size == 1
+
+      def isNonPrimitiveValueClass(tpe: c.universe.Type): Boolean = {
+        tpe <:< typeOf[AnyVal] &&
+        tpe.typeSymbol.isClass &&
+        tpe.typeSymbol.asClass.isCaseClass &&
+        getAccessors(tpe).size == 1 &&
+        getAccessors(getAccessors(tpe).head.returnType).nonEmpty
+      }
 
       // utils
       def getAccessors(tpe: c.universe.Type): Iterable[c.universe.MethodSymbol] =

--- a/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
+++ b/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
@@ -58,7 +58,7 @@ object ParamNameExtractor {
           report.errorAndAbort(s"Unsupported path [${path.show}]")
       }
 
-      val res = Expr(
+      Expr(
         ParamName[T](
           pathElements
             .map {
@@ -68,10 +68,6 @@ object ParamNameExtractor {
             .mkString(".")
         )
       )
-      report.info(
-        s"Currently at ${res.show}\nfor path ${path.show}\non term ${path.asTerm}"
-      )
-      res
     }
 
   }

--- a/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
+++ b/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
@@ -6,7 +6,7 @@ import cats.xml.utils.generic.ParamName
 import scala.quoted.*
 
 class ParamNameExtractor[T] private () {
-  inline def param[U](path: T => U): ParamName[T] =
+  inline def param[U](inline path: T => U): ParamName[T] =
     ${ ParamNameExtractor.Scala3Macros.extractParamName[T, U]('path) }
 }
 object ParamNameExtractor {
@@ -54,13 +54,11 @@ object ParamNameExtractor {
         /** Single inlined path */
         case Inlined(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
           toPath(p, List.empty)
-//        case Expr(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
-//          toPath(p, List.empty)
         case _ =>
           report.errorAndAbort(s"Unsupported path [${path.show}]")
       }
 
-      Expr(
+      val res = Expr(
         ParamName[T](
           pathElements
             .map {
@@ -70,6 +68,11 @@ object ParamNameExtractor {
             .mkString(".")
         )
       )
+      report.info(
+        s"Currently at ${res.show}\nfor path ${path.show}\non term ${path.asTerm}"
+      )
+      res
     }
+
   }
 }

--- a/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
+++ b/internal-utils/src/main/scala-3/cats/xml/utils/generic/ParamNameExtractor.scala
@@ -54,8 +54,10 @@ object ParamNameExtractor {
         /** Single inlined path */
         case Inlined(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
           toPath(p, List.empty)
+//        case Expr(_, _, Block(List(DefDef(_, _, _, Some(p))), _)) =>
+//          toPath(p, List.empty)
         case _ =>
-          report.errorAndAbort(s"Unsupported path [$path]")
+          report.errorAndAbort(s"Unsupported path [${path.show}]")
       }
 
       Expr(

--- a/internal-utils/src/main/scala-3/cats/xml/utils/generic/typeInfoInstances.scala
+++ b/internal-utils/src/main/scala-3/cats/xml/utils/generic/typeInfoInstances.scala
@@ -34,6 +34,7 @@ object TypeInfoInstances {
         val isPrimitiveWrapper: Expr[Boolean]                   = Expr(utils.isPrimitiveWrapper[T])
         val isPrimitive: Expr[Boolean]                          = Expr(utils.isPrimitive[T])
         val isValueClass: Expr[Boolean]                         = Expr(utils.isValueClass[T])
+        val isNonPrimitiveValueClass: Expr[Boolean] = Expr(utils.isNonPrimitiveValueClass[T])
         val isOptionOfAnyPrimitiveOrString: Expr[Boolean] = Expr(
           utils.isOptionOfAnyPrimitiveOrString[T]
         )
@@ -45,7 +46,8 @@ object TypeInfoInstances {
             isPrimitive                    = ${ isPrimitive },
             isValueClass                   = ${ isValueClass },
             isOptionOfAnyPrimitiveOrString = ${ isOptionOfAnyPrimitiveOrString },
-            accessorsInfo                  = ${ accessorsInfo }
+            accessorsInfo                  = ${ accessorsInfo },
+            isNonPrimitiveValueClass       = ${ isNonPrimitiveValueClass }
           )
         }
       }
@@ -134,6 +136,14 @@ object TypeInfoInstances {
         (tpe <:< anyValTypeRepr)
         && tpe.classSymbol.exists(cs => cs.flags.is(Flags.Case) && cs.isClassDef)
         && getAccessors[T].size == 1
+      }
+
+      def isNonPrimitiveValueClass[T: Type]: Boolean = {
+        val tpe = TypeRepr.of[T]
+        (tpe <:< anyValTypeRepr)
+        && tpe.classSymbol.exists(cs => cs.flags.is(Flags.Case) && cs.isClassDef)
+        && getAccessors[T].size == 1
+        && getAccessors[T].head.tree.symbol.fieldMembers.size > 0
       }
 
       // utils

--- a/internal-utils/src/main/scala/cats/xml/utils/generic/TypeInfo.scala
+++ b/internal-utils/src/main/scala/cats/xml/utils/generic/TypeInfo.scala
@@ -8,7 +8,8 @@ case class TypeInfo[T](
   isPrimitive: Boolean,
   isValueClass: Boolean,
   isOptionOfAnyPrimitiveOrString: Boolean,
-  accessorsInfo: Map[ParamName[T], TypeInfo[?]]
+  accessorsInfo: Map[ParamName[T], TypeInfo[?]],
+  isNonPrimitiveValueClass: Boolean
 ) {
   override def toString: String = Show[TypeInfo[T]].show(this)
 }
@@ -22,14 +23,16 @@ object TypeInfo extends TypeInfoInstances {
     isPrimitive: Boolean,
     isValueClass: Boolean,
     isOptionOfAnyPrimitiveOrString: Boolean,
-    accessorsInfo: Map[ParamName[T], TypeInfo[?]]
+    accessorsInfo: Map[ParamName[T], TypeInfo[?]],
+    isNonPrimitiveValueClass: Boolean
   ): TypeInfo[T] = new TypeInfo[T](
     isString,
     isPrimitiveWrapper,
     isPrimitive,
     isValueClass,
     isOptionOfAnyPrimitiveOrString,
-    accessorsInfo
+    accessorsInfo,
+    isNonPrimitiveValueClass
   )
 
   def of[T](
@@ -38,22 +41,26 @@ object TypeInfo extends TypeInfoInstances {
     isPrimitive: Boolean,
     isValueClass: Boolean,
     isOptionOfAnyPrimitiveOrString: Boolean,
-    accessorsInfo: Map[ParamName[T], TypeInfo[?]]
+    accessorsInfo: Map[ParamName[T], TypeInfo[?]],
+    isNonPrimitiveValueClass: Boolean
   ): TypeInfo[T] = TypeInfo[T](
     isString,
     isPrimitiveWrapper,
     isPrimitive,
     isValueClass,
     isOptionOfAnyPrimitiveOrString,
-    accessorsInfo
+    accessorsInfo,
+    isNonPrimitiveValueClass
   )
 
   implicit def showTypeInfo[T]: Show[TypeInfo[T]] =
-    (t: TypeInfo[T]) => s"""
+    (t: TypeInfo[T]) =>
+      s"""
        |isString:  ${t.isString}
        |isPrimitiveWrapper: ${t.isPrimitive}
        |isPrimitive: ${t.isPrimitive}
        |isValueClass: ${t.isValueClass}
        |isOptionOfAnyPrimitiveOrString: ${t.isValueClass}
-       |accessorsInfo: ${t.accessorsInfo}""".stripMargin
+       |accessorsInfo: ${t.accessorsInfo}
+       |isNonPrimitiveValueClass: ${t.isNonPrimitiveValueClass}""".stripMargin
 }

--- a/internal-utils/src/test/scala/cats/xml/utils/generic/TypeInfoSuite.scala
+++ b/internal-utils/src/test/scala/cats/xml/utils/generic/TypeInfoSuite.scala
@@ -1,9 +1,16 @@
 package cats.xml.utils.generic
 
-class TypeInfoSuite extends munit.FunSuite {
-
-  case class Foo(a: String, b: Option[Int], c: Bar)
+object TypeInfoSuite {
+  case class Foo(a: String, b: Option[Int], c: Bar, c2: Qux, c3: Quux)
   case class Bar(d: String)
+  case class Baz(e: String)
+  case class Qux(f: Baz) extends AnyVal
+  case class Quux(g: String) extends AnyVal
+}
+
+import cats.xml.utils.generic.TypeInfoSuite.*
+
+class TypeInfoSuite extends munit.FunSuite {
 
   test("TypeInfo.deriveTypeInfo derives the right information for the type Foo") {
     val fooTypeInfo: TypeInfo[Foo] = TypeInfo.deriveTypeInfo[Foo]
@@ -15,6 +22,7 @@ class TypeInfoSuite extends munit.FunSuite {
         isPrimitive                    = false,
         isValueClass                   = false,
         isOptionOfAnyPrimitiveOrString = false,
+        isNonPrimitiveValueClass       = false,
         accessorsInfo = Map(
           ParamName(
             value = "a"
@@ -24,6 +32,7 @@ class TypeInfoSuite extends munit.FunSuite {
             isPrimitive                    = false,
             isValueClass                   = false,
             isOptionOfAnyPrimitiveOrString = false,
+            isNonPrimitiveValueClass       = false,
             accessorsInfo                  = Map.empty[ParamName[String], TypeInfo[?]]
           ),
           ParamName(
@@ -34,6 +43,7 @@ class TypeInfoSuite extends munit.FunSuite {
             isPrimitive                    = false,
             isValueClass                   = false,
             isOptionOfAnyPrimitiveOrString = true,
+            isNonPrimitiveValueClass       = false,
             accessorsInfo                  = Map.empty[ParamName[Option[Int]], TypeInfo[?]]
           ),
           ParamName(
@@ -44,6 +54,7 @@ class TypeInfoSuite extends munit.FunSuite {
             isPrimitive                    = false,
             isValueClass                   = false,
             isOptionOfAnyPrimitiveOrString = false,
+            isNonPrimitiveValueClass       = false,
             accessorsInfo = Map(
               ParamName(
                 value = "d"
@@ -53,6 +64,65 @@ class TypeInfoSuite extends munit.FunSuite {
                 isPrimitive                    = false,
                 isValueClass                   = false,
                 isOptionOfAnyPrimitiveOrString = false,
+                isNonPrimitiveValueClass       = false,
+                accessorsInfo                  = Map.empty[ParamName[String], TypeInfo[?]]
+              )
+            )
+          ),
+          ParamName(
+            value = "c2"
+          ) -> TypeInfo.of[Qux](
+            isString                       = false,
+            isPrimitiveWrapper             = false,
+            isPrimitive                    = false,
+            isValueClass                   = true,
+            isOptionOfAnyPrimitiveOrString = false,
+            isNonPrimitiveValueClass       = true,
+            accessorsInfo = Map(
+              ParamName(
+                value = "f"
+              ) -> TypeInfo.of[Baz](
+                isString                       = false,
+                isPrimitiveWrapper             = false,
+                isPrimitive                    = false,
+                isValueClass                   = false,
+                isOptionOfAnyPrimitiveOrString = false,
+                isNonPrimitiveValueClass       = false,
+                accessorsInfo = Map(
+                  ParamName(
+                    value = "e"
+                  ) -> TypeInfo.of[String](
+                    isString                       = true,
+                    isPrimitiveWrapper             = false,
+                    isPrimitive                    = false,
+                    isValueClass                   = false,
+                    isOptionOfAnyPrimitiveOrString = false,
+                    isNonPrimitiveValueClass       = false,
+                    accessorsInfo                  = Map.empty[ParamName[String], TypeInfo[?]]
+                  )
+                )
+              )
+            )
+          ),
+          ParamName(
+            value = "c3"
+          ) -> TypeInfo.of[Quux](
+            isString                       = false,
+            isPrimitiveWrapper             = false,
+            isPrimitive                    = false,
+            isValueClass                   = true,
+            isOptionOfAnyPrimitiveOrString = false,
+            isNonPrimitiveValueClass       = false,
+            accessorsInfo = Map(
+              ParamName(
+                value = "g"
+              ) -> TypeInfo.of[String](
+                isString                       = true,
+                isPrimitiveWrapper             = false,
+                isPrimitive                    = false,
+                isValueClass                   = false,
+                isOptionOfAnyPrimitiveOrString = false,
+                isNonPrimitiveValueClass       = false,
                 accessorsInfo                  = Map.empty[ParamName[String], TypeInfo[?]]
               )
             )

--- a/modules/generic/src/main/scala-3/cats/xml/generic/DerivationHack.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/DerivationHack.scala
@@ -1,0 +1,138 @@
+package cats.xml.generic
+
+import magnolia1.Macro.{anns, inheritedAnns, isEnum, isObject, paramTypeAnns, typeInfo}
+import magnolia1.{CallByNeed, CaseClass, CaseClassDerivation, SealedTrait}
+
+import scala.annotation.nowarn
+import scala.compiletime.{erasedValue, summonFrom, summonInline}
+import scala.deriving.Mirror
+
+private trait SerializableFunction0[+R] extends Function0[R] with Serializable:
+  def apply(): R
+
+private trait SerializableFunction1[-T1, +R] extends Function1[T1, R] with Serializable:
+  def apply(v1: T1): R
+
+trait DerivationHack[TypeClass[_], Params[_]] {
+  protected inline def sealedTraitFromMirror[A](
+    m: Mirror.SumOf[A]
+  ): SealedTrait[Typeclass, A] =
+    SealedTrait(
+      typeInfo[A],
+      IArray(subtypesFromMirror[A, m.MirroredElemTypes](m)*),
+      IArray.from(anns[A]),
+      IArray(paramTypeAnns[A]*),
+      isEnum[A],
+      IArray.from(inheritedAnns[A])
+    )
+
+  @nowarn protected transparent inline def subtypesFromMirror[A, SubtypeTuple <: Tuple](
+    m: Mirror.SumOf[A],
+    idx: Int                                           = 0, // no longer used, kept for bincompat
+    result: List[SealedTrait.Subtype[Typeclass, A, _]] = Nil
+  ): List[SealedTrait.Subtype[Typeclass, A, _]] =
+    inline erasedValue[SubtypeTuple] match
+      case _: EmptyTuple =>
+        result.distinctBy(_.typeInfo).sortBy(_.typeInfo.full)
+      case _: (s *: tail) =>
+        val sub = summonFrom {
+          case mm: Mirror.SumOf[`s`] =>
+            subtypesFromMirror[A, mm.MirroredElemTypes](
+              mm.asInstanceOf[m.type],
+              0,
+              Nil
+            )
+          case _ => {
+            val tc = new SerializableFunction0[Typeclass[s]]:
+              override def apply(): Typeclass[s] = summonFrom {
+                case tc: Typeclass[`s`] => tc
+                case _ => deriveSubtype(summonInline[Mirror.Of[s]], summonInline[Params[s]])
+              }
+            val isType = new SerializableFunction1[A, Boolean]:
+              override def apply(a: A): Boolean = a.isInstanceOf[s & A]
+            val asType = new SerializableFunction1[A, s & A]:
+              override def apply(a: A): s & A = a.asInstanceOf[s & A]
+            List(
+              new SealedTrait.Subtype[Typeclass, A, s](
+                typeInfo[s],
+                IArray.from(anns[s]),
+                IArray.from(inheritedAnns[s]),
+                IArray.from(paramTypeAnns[A]),
+                isObject[s],
+                idx,
+                CallByNeed.createLazy(tc),
+                isType,
+                asType
+              )
+            )
+          }
+        }
+        subtypesFromMirror[A, tail](m, idx + 1, sub ::: result)
+  // From CommonDerivation
+  type Typeclass[T] = TypeClass[T]
+
+  inline def getParams[T, Labels <: Tuple, Params <: Tuple](
+    annotations: Map[String, List[Any]],
+    inheritedAnnotations: Map[String, List[Any]],
+    typeAnnotations: Map[String, List[Any]],
+    repeated: Map[String, Boolean],
+    defaults: Map[String, Option[() => Any]]
+  ): List[CaseClass.Param[Typeclass, T]] = CaseClassDerivation.paramsFromMaps(
+    annotations,
+    inheritedAnnotations,
+    typeAnnotations,
+    repeated,
+    defaults
+  )
+
+  // From Bar
+  def join[T: Params](caseClass: CaseClass[Typeclass, T]): Typeclass[T]
+
+  inline def derivedMirrorProduct[A: Params](
+    product: Mirror.ProductOf[A]
+  ): Typeclass[A] = join(CaseClassDerivation.fromMirror(product))
+
+  // From Derivation
+  final type Ps[S] = Params[S]
+
+  def split[T: Params](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T]
+
+  transparent inline def subtypes[T, SubtypeTuple <: Tuple](
+    m: Mirror.SumOf[T],
+    idx: Int = 0 // no longer used, kept for bincompat
+  ): List[SealedTrait.Subtype[Typeclass, T, _]] =
+    subtypesFromMirror[T, SubtypeTuple](m, idx)
+
+  inline def derivedMirrorSum[A: Params](sum: Mirror.SumOf[A]): Typeclass[A] =
+    split(sealedTraitFromMirror(sum))
+
+  // From Foo and Derivation
+  inline def derivedMirror[A](using mirror: Mirror.Of[A], i: Params[A]): Typeclass[A] =
+    inline mirror match
+      case sum: Mirror.SumOf[A]         => derivedMirrorSum[A](sum)
+      case product: Mirror.ProductOf[A] => derivedMirrorProduct[A](product)
+
+//  inline def derived[A](using Mirror.Of[A], Params[A]): Typeclass[A] = derivedMirror[A]
+
+  protected inline def deriveSubtype[s](
+    m: Mirror.Of[s],
+    i: Params[s]
+  ): Typeclass[s] = derivedMirror[s](using m, i)
+
+  // for foo
+  inline def derived[A](using mirror: Mirror.Of[A]): Typeclass[A] =
+    summonFrom {
+      case p: Params[A] => derivedMirror[A](using mirror, p)
+      case _            => derivedMirror[A](using mirror, default[A])
+    }
+
+  def default[A]: Params[A] = throw new IllegalStateException("No default implemented")
+
+  inline def derived[T <: AnyVal: Params]: TypeClass[T] = handleAnyVal[T]
+
+  inline def handleAnyVal[A <: AnyVal: Params]: TypeClass[A]
+}
+
+trait AutoDerivationHack[TypeClass[_], Params[_]] extends DerivationHack[TypeClass, Params]:
+  inline given autoDerived[A](using Mirror.Of[A], Params[A]): TypeClass[A] = derivedMirror[A]
+  inline given autoDerived[A <: AnyVal: Params]: TypeClass[A]              = derived[A]

--- a/modules/generic/src/main/scala-3/cats/xml/generic/DerivationHack.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/DerivationHack.scala
@@ -128,11 +128,16 @@ trait DerivationHack[TypeClass[_], Params[_]] {
 
   def default[A]: Params[A] = throw new IllegalStateException("No default implemented")
 
-  inline def derived[T <: AnyVal: Params]: TypeClass[T] = handleAnyVal[T]
+  inline def derived[T <: AnyVal & Product: Params]: TypeClass[T] = handleAnyVal[T]
 
-  inline def handleAnyVal[A <: AnyVal: Params]: TypeClass[A]
+  inline def handleAnyVal[A <: AnyVal & Product: Params]: TypeClass[A]
+  inline def handlePrimitive[A]: TypeClass[A]
+
+  // alias because I can't write macros well enough to avoid it r/n
+  inline def mirrorDerived[A](using mirror: Mirror.Of[A]): Typeclass[A] = derived[A]
+  inline def noMirrorDerived[A]: Typeclass[A]                           = handlePrimitive[A]
 }
 
 trait AutoDerivationHack[TypeClass[_], Params[_]] extends DerivationHack[TypeClass, Params]:
   inline given autoDerived[A](using Mirror.Of[A], Params[A]): TypeClass[A] = derivedMirror[A]
-  inline given autoDerived[A <: AnyVal: Params]: TypeClass[A]              = derived[A]
+  inline given autoDerived[A <: AnyVal & Product: Params]: TypeClass[A]    = derived[A]

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
@@ -149,10 +149,16 @@ object DecoderMacros {
       case '[t] =>
         val decoder =
           if (theType.symbol.isClassDef)
-            TypeApply(
-              Select.unique(self.asTerm, "mirrorDerived"),
-              List(theType)
-            )
+            Implicits.search(TypeRepr.of[scala.deriving.Mirror.Of[t]]) match {
+              case mirror: ImplicitSearchSuccess =>
+                Apply(
+                  TypeApply(
+                    Select.unique(self.asTerm, "mirrorDerived"),
+                    List(theType)
+                  ),
+                  List(mirror.tree)
+                )
+            }
           else
             TypeApply(
               Select.unique(self.asTerm, "noMirrorDerived"),

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
@@ -1,94 +1,109 @@
-//package cats.xml.generic
-//
-//import cats.data.NonEmptyList
-//import cats.xml.*
-//import cats.xml.codec.{Decoder, DecoderFailure}
-//import cats.xml.cursor.{CursorFailure, FreeCursor}
-//import cats.xml.generic.{Configuration, XmlElemType, XmlTypeInterpreter}
-//import cats.xml.utils.generic.ParamName
-//import magnolia1.*
-//import magnolia1.CaseClass.Param
-//
-//import scala.deriving.Mirror
-//
-//object MagnoliaDecoder extends AutoDerivation[Decoder]:
-//
-//  import cats.syntax.all.given
-//
-//  val config: Configuration = Configuration.default
-//
-//  override def join[T](ctx: CaseClass[Typeclass, T]): Typeclass[T] =
-//    if (ctx.isValueClass && config.unwrapValueClasses) {
-//      ctx.params.head.typeclass.map(v => ctx.rawConstruct(Seq(v)))
-//    } else {
-//      val interpreter: XmlTypeInterpreter[T] = XmlTypeInterpreter[T]
-//
-//      Decoder
-//        .fromCursor(c => {
-//          ctx.params.toList
-//            .mapFilter { (param: Param[Decoder, T]) =>
-//              given Decoder[param.PType] = param.typeclass
-//
-//              interpreter
-//                .evalParam(ParamName[T](param.label))
-//                .mapFilter(paramInfo => {
-//
-//                  // normalize element label
-//                  val normalizedLabel: String = paramInfo.labelMapper(param.label)
-//
-//                  // find and decoder element
-//                  val result: Option[FreeCursor[param.PType]] = paramInfo.elemType match {
-//                    case XmlElemType.Attribute => Some(c.attr(normalizedLabel).as[param.PType])
-//                    case XmlElemType.Child     => Some(c.down(normalizedLabel).as[param.PType])
-//                    case XmlElemType.Text      => Some(c.text.as[param.PType])
-//                    case XmlElemType.Null      => None
-//                  }
-//
-//                  // use fault parameter in case of missing element
-//                  if (config.useDefaults)
-//                    result.map(
-//                      _.recoverWith(
-//                        useDefaultParameterIfPresentToRecoverMissing[Decoder, T, param.PType](param)
-//                      )
-//                    )
-//                  else
-//                    result
-//                })
-//            }
-//            .toList
-//            .sequence
-//            .map(ctx.rawConstruct)
-//        })
-//    }
-//
-//  override def split[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T] =
-//    Decoder.fromXml(xml => {
+package cats.xml.generic
+
+import cats.data.NonEmptyList
+import cats.xml.*
+import cats.xml.codec.{Decoder, DecoderFailure}
+import cats.xml.cursor.{CursorFailure, FreeCursor}
+import cats.xml.generic.{Configuration, XmlElemType, XmlTypeInterpreter}
+import cats.xml.utils.generic.ParamName
+import magnolia1.*
+import magnolia1.CaseClass.Param
+
+import scala.deriving.Mirror
+
+object MagnoliaDecoder extends AutoDerivation[Decoder]:
+
+  import cats.syntax.all.given
+
+  val config: Configuration = Configuration.default
+  implicit class CantRememberHowToDoThisInScala3(o: Decoder.type) {
+    inline def derived[A](using Mirror.Of[A]): Decoder[A] = MagnoliaDecoder.derived[A]
+  }
+
+  override def join[T](ctx: CaseClass[Typeclass, T]): Typeclass[T] =
+    if (ctx.isValueClass && config.unwrapValueClasses) {
+      ctx.params.head.typeclass.map(v => ctx.rawConstruct(Seq(v)))
+    } else {
+      val interpreter: XmlTypeInterpreter[T] = XmlTypeInterpreter[T]
+
+      Decoder
+        .fromCursor(c => {
+          ctx.params.toList
+            .mapFilter { (param: Param[Decoder, T]) =>
+              given Decoder[param.PType] = param.typeclass
+
+              interpreter
+                .evalParam(ParamName[T](param.label))
+                .mapFilter(paramInfo => {
+
+                  // normalize element label
+                  val normalizedLabel: String = paramInfo.labelMapper(param.label)
+
+                  // find and decoder element
+                  val result: Option[FreeCursor[param.PType]] = paramInfo.elemType match {
+                    case XmlElemType.Attribute => Some(c.attr(normalizedLabel).as[param.PType])
+                    case XmlElemType.Child     => Some(c.down(normalizedLabel).as[param.PType])
+                    case XmlElemType.Text      => Some(c.text.as[param.PType])
+                    case XmlElemType.Null      => None
+                  }
+
+                  // use fault parameter in case of missing element
+                  if (config.useDefaults)
+                    result.map(
+                      _.recoverWith(
+                        useDefaultParameterIfPresentToRecoverMissing[Decoder, T, param.PType](param)
+                      )
+                    )
+                  else
+                    result
+                })
+            }
+            .toList
+            .sequence
+            .map(ctx.rawConstruct)
+        })
+    }
+
+  override def split[T](ctx: SealedTrait[Typeclass, T]): Typeclass[T] =
+    Decoder.instance(xml => {
 //      val subtypeTypeClass: Option[SealedTrait.Subtype[Typeclass, T, _]] = xml match
 //        case node: XmlNode =>
 //          ctx.subtypes.toList.find(_.typeInfo.short == node.label)
 //        case _ =>
 //          ctx.subtypes.headOption
-//
-//      subtypeTypeClass.map(_.typeclass.decode(xml)) match
-//        case Some(result) => result
-//        case None =>
-//          DecoderFailure
-//            .Custom(
-//              s"Cannot find a valid subtype for sealed trait ${ctx.typeInfo.toString}"
-//            )
-//            .invalidNel
-//    })
-//
-//  // Internal error: unable to find the outer accessor symbol of class $read
-//  private def useDefaultParameterIfPresentToRecoverMissing[F[_], T, PT](
-//    param: Param[F, T]
-//  ): PartialFunction[NonEmptyList[CursorFailure], FreeCursor[PT]] = { failures =>
-//    if (failures.forall(_.isMissing))
-//      param.default match {
-//        case Some(value) =>
-//          FreeCursor.const[Xml, PT](value.asInstanceOf[PT].validNel[CursorFailure])
-//        case None => FreeCursor.failure(failures)
-//      }
-//    else
-//      FreeCursor.failure(failures)
-//  }
+
+      val subtypeTypeClass: Option[SealedTrait.Subtype[Typeclass, T, _]] = xml match {
+        case node: XmlNode =>
+          val target: String = (config.discriminatorAttrKey match {
+            case Some(discriminatorAttrKey) => node.findAttr[String](discriminatorAttrKey)
+            case None                       => node.label.some
+          }).getOrElse(node.label)
+
+          ctx.subtypes.find(_.typeInfo.short == target)
+        case _ =>
+          ctx.subtypes.headOption
+      }
+
+      subtypeTypeClass.map(_.typeclass.decode(xml)) match
+        case Some(result) => result
+        case None =>
+          DecoderFailure
+            .Custom(
+              s"Cannot find a valid subtype for sealed trait ${ctx.typeInfo.toString}"
+            )
+            .invalidNel
+    })
+
+  // Internal error: unable to find the outer accessor symbol of class $read
+  private def useDefaultParameterIfPresentToRecoverMissing[F[_], T, PT](
+    param: Param[F, T]
+  ): PartialFunction[NonEmptyList[CursorFailure], FreeCursor[PT]] = { failures =>
+    if (failures.forall(_.isMissing))
+      param.default match {
+        case Some(value) =>
+          FreeCursor.const[PT](value.asInstanceOf[PT].validNel[CursorFailure])
+        case None => FreeCursor.failure(failures)
+      }
+    else
+      FreeCursor.failure(failures)
+  }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
@@ -121,6 +121,8 @@ class MagnoliaDecoder(config: Configuration)
     case _              => deriveAnyValSupport[A].decoder
   }
 
+  // Since there's no 'Mirror.Of' for user-defined AnyVals, we attempt to summon the Decoder for the wrapped type
+  // from within a macro, and map it to a decoder for the wrapper with the wrapper's constructor
   inline implicit def deriveAnyValSupport[A <: AnyVal & Product: XmlTypeInterpreter]: FullSupp[A] =
     ${
       DecoderMacros.deriveAnyValSupportImpl[A]('this)

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaDecoder.scala
@@ -30,7 +30,7 @@ class MagnoliaDecoder(config: Configuration)
 
   import cats.syntax.all.given
 
-  override def join[T: XmlTypeInterpreter](ctx: CaseClass[Typeclass, T]): Typeclass[T] =
+  override def join[T: XmlTypeInterpreter](ctx: CaseClass[Decoder, T]): Decoder[T] =
     if (ctx.isValueClass && config.unwrapValueClasses) {
       ctx.params.head.typeclass.map(v => ctx.rawConstruct(Seq(v)))
     } else {
@@ -78,9 +78,9 @@ class MagnoliaDecoder(config: Configuration)
         })
     }
 
-  override def split[T: XmlTypeInterpreter](ctx: SealedTrait[Typeclass, T]): Typeclass[T] =
+  override def split[T: XmlTypeInterpreter](ctx: SealedTrait[Decoder, T]): Decoder[T] =
     Decoder.instance(xml => {
-      val subtypeTypeClass: Option[SealedTrait.Subtype[Typeclass, T, _]] = xml match {
+      val subtypeTypeClass: Option[SealedTrait.Subtype[Decoder, T, _]] = xml match {
         case node: XmlNode =>
           val target: String = (config.discriminatorAttrKey match {
             case Some(discriminatorAttrKey) => node.findAttr[String](discriminatorAttrKey)

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
@@ -63,9 +63,6 @@ class MagnoliaEncoder(config: Configuration)
               XmlNode(paramInfo.labelMapper(param.label), content = NodeContent.text(node))
             )
           )
-        case node: XmlNode
-            if paramInfo.elemType == XmlElemType.Attribute || paramInfo.elemType == XmlElemType.Text =>
-          ???
         case xml => throw new RuntimeException(debugMsg(xml, param, paramInfo))
       }
 

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
@@ -1,0 +1,125 @@
+package cats.xml.generic
+
+import cats.xml.*
+import cats.xml.codec.Encoder
+import cats.xml.utils.generic.ParamName
+import cats.xml.utils.impure
+import magnolia1.*
+import scala.compiletime.summonFrom
+
+class MagnoliaEncoder(config: Configuration) extends AutoDerivation[Encoder] {
+
+  import cats.xml.syntax.*
+  private inline def summonInterpreter[T] = summonFrom {
+    case interpreter: XmlTypeInterpreter[T] => interpreter
+    case _ => throw new IllegalStateException("No interpreter for type")
+  }
+
+  def join[T](
+    ctx: CaseClass[Encoder, T]
+  ): Encoder[T] = {
+    if (ctx.isValueClass && config.unwrapValueClasses) {
+      val valueParam: CaseClass.Param[Encoder, T] = ctx.parameters.head
+      valueParam.typeclass.contramap[T](valueParam.deref(_))
+    } else {
+      val interpreter: XmlTypeInterpreter[T] = summonInterpreter[T]
+
+      Encoder.of(t => {
+
+        val nodeBuild: XmlNode.Node = XmlNode(ctx.typeInfo.short)
+
+        def evaluateAndAppend(
+          xml: Xml,
+          param: CaseClass.Param[Encoder, T],
+          paramInfo: XmlElemTypeParamInfo
+        ): Unit =
+          xml match {
+            case XmlNull => ()
+            case data: XmlData if paramInfo.elemType == XmlElemType.Attribute =>
+              nodeBuild.unsafeMuteNode(
+                _.appendAttr(
+                  XmlAttribute(
+                    key   = paramInfo.labelMapper(param.label),
+                    value = data
+                  )
+                )
+              )
+            case data: XmlData if paramInfo.elemType == XmlElemType.Text =>
+              nodeBuild.unsafeMuteNode(_.withText(data))
+            case node: XmlNode if paramInfo.elemType == XmlElemType.Child =>
+              nodeBuild.unsafeMuteNode(_.appendChildren(node))
+            case xml => throw new RuntimeException(debugMsg(xml, param, paramInfo))
+          }
+
+        ctx.parameters.foreach(param =>
+          interpreter
+            .evalParam(ParamName(param.label))
+            .foreach((paramInfo: XmlElemTypeParamInfo) => {
+              evaluateAndAppend(
+                xml       = param.typeclass.encode(param.deref(t)),
+                param     = param,
+                paramInfo = paramInfo
+              )
+            })
+        )
+
+        nodeBuild
+      })
+    }
+  }
+
+  @impure
+  def split[T](
+    sealedTrait: SealedTrait[Encoder, T]
+  ): Encoder[T] = { (a: T) =>
+    sealedTrait.choose(a) { subtype =>
+      val subTypeXml = subtype.typeclass.encode(subtype.cast(a))
+      config.discriminatorAttrKey match {
+        case Some(discriminatorAttrKey) =>
+          val base = XmlNode(sealedTrait.typeInfo.short)
+            .withAttrs(
+              discriminatorAttrKey := subtype.typeInfo.short
+            )
+
+          subTypeXml match {
+            case group: XmlNode.Group => base.withContent(group.content)
+            case node: XmlNode.Node =>
+              base
+                .appendAttrs(node.attributes)
+                .withContent(node.content)
+            case attr: XmlAttribute => base.appendAttr(attr)
+            case data: XmlData      => base.withText(data)
+            case _                  => base
+          }
+
+        case None => subTypeXml
+      }
+    }
+  }
+
+  private def debugMsg[TC[_], T](
+    xml: Xml,
+    p: CaseClass.Param[TC, T],
+    paramInfo: XmlElemTypeParamInfo
+  ): String =
+    s"""
+       |Unable to handle an Xml element.
+       |
+       |Try to change your `XmlTypeInterpreter` implementation for type `${p.typeclass}` in order to
+       |let the field `${p.label}` fall in one of the following supported cases:
+       |
+       |- XmlNode as XmlElemType.Child
+       |- XmlData as XmlElemType.Attribute
+       |- XmlData as XmlElemType.Text
+       |
+       |Current:
+       |- ${xml.getClass.getSimpleName} as ${paramInfo.elemType}
+       |
+       |---------------------------------
+       |Xml instance value: $xml
+       |Xml instance type: ${xml.getClass.getName}
+       |Field name: ${p.label}
+       |Field type: ${p.typeclass}
+       |Treated as: ${paramInfo.elemType}
+       |""".stripMargin
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
@@ -144,6 +144,8 @@ class MagnoliaEncoder(config: Configuration)
     case _                 => deriveAnyValSupport[A].encoder
   }
 
+  // Since there's no 'Mirror.Of' for user-defined AnyVals, we attempt to summon the Encoder for the wrapped type
+  // from within a macro, and contramap it to an encoder for the wrapper via singleton field access
   inline implicit def deriveAnyValSupport[A <: AnyVal & Product: XmlTypeInterpreter]
     : FullEncSupp[A] =
     ${

--- a/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/MagnoliaEncoder.scala
@@ -27,12 +27,11 @@ class MagnoliaEncoder(config: Configuration)
 
   import cats.xml.syntax.*
 
-  def join[T: Ps](
-    ctx: CaseClass[Typeclass, T]
-  ): Typeclass[T] = Encoder.of(t => {
+  def join[T: XmlTypeInterpreter](
+    ctx: CaseClass[Encoder, T]
+  ): Encoder[T] = Encoder.of(t => {
 
     val nodeBuild: XmlNode.Node = XmlNode(ctx.typeInfo.short)
-
     def evaluateAndAppend(
       xml: Xml,
       param: CaseClass.Param[Encoder, T],

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/auto.scala
@@ -8,7 +8,8 @@ import scala.deriving.Mirror
 object auto {
   private final val defaultDecoder = new MagnoliaDecoder(Configuration.default)
 
-  inline given deriveDecoder[T](using Mirror.Of[T]): Decoder[T] = defaultDecoder.autoDerived[T]
+  inline given deriveDecoder[T: Mirror.Of: XmlTypeInterpreter]: Decoder[T] =
+    defaultDecoder.autoDerived[T]
   inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Decoder[T] =
     defaultDecoder.autoDerived[T]
 

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/auto.scala
@@ -1,0 +1,11 @@
+package cats.xml.generic.decoder
+
+import cats.xml.codec.Decoder
+import cats.xml.generic.{Configuration, MagnoliaDecoder}
+import scala.deriving.Mirror
+
+object auto {
+
+  inline given deriveDecoder[T](using Mirror.Of[T]): Decoder[T] = MagnoliaDecoder.autoDerived[T]
+
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/auto.scala
@@ -1,0 +1,17 @@
+package cats.xml.generic.decoder.configured
+
+import cats.xml.codec.Decoder
+import cats.xml.generic.{Configuration, MagnoliaDecoder, XmlTypeInterpreter}
+
+import scala.deriving.Mirror
+
+object auto {
+
+  inline given deriveConfiguredDecoder[T](using m: Mirror.Of[T], c: Configuration): Decoder[T] =
+    new MagnoliaDecoder(c).autoDerived[T]
+  inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+    c: Configuration
+  ): Decoder[T] =
+    new MagnoliaDecoder(c).autoDerived[T]
+
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/auto.scala
@@ -7,11 +7,11 @@ import scala.deriving.Mirror
 
 object auto {
 
-  inline given deriveConfiguredDecoder[T](using m: Mirror.Of[T], c: Configuration): Decoder[T] =
-    new MagnoliaDecoder(c).autoDerived[T]
-  inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+  inline given deriveConfiguredDecoder[T: Mirror.Of: XmlTypeInterpreter](using
     c: Configuration
-  ): Decoder[T] =
-    new MagnoliaDecoder(c).autoDerived[T]
+  ): Decoder[T] = new MagnoliaDecoder(c).autoDerived[T]
+  inline given deriveConfiguredDecoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+    c: Configuration
+  ): Decoder[T] = new MagnoliaDecoder(c).autoDerived[T]
 
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/semiauto.scala
@@ -7,8 +7,9 @@ import scala.deriving.Mirror
 
 object semiauto {
 
-  inline def deriveConfiguredDecoder[T: Mirror.Of](using c: Configuration): Decoder[T] =
-    new MagnoliaDecoder(c).autoDerived[T]
+  inline def deriveConfiguredDecoder[T: Mirror.Of: XmlTypeInterpreter](using
+    c: Configuration
+  ): Decoder[T] = new MagnoliaDecoder(c).autoDerived[T]
   inline def deriveConfiguredDecoder[T <: AnyVal & Product: XmlTypeInterpreter](using
     c: Configuration
   ): Decoder[T] = new MagnoliaDecoder(c).autoDerived[T]

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/configured/semiauto.scala
@@ -1,0 +1,16 @@
+package cats.xml.generic.decoder.configured
+
+import cats.xml.codec.Decoder
+import cats.xml.generic.{Configuration, MagnoliaDecoder, XmlTypeInterpreter}
+
+import scala.deriving.Mirror
+
+object semiauto {
+
+  inline def deriveConfiguredDecoder[T: Mirror.Of](using c: Configuration): Decoder[T] =
+    new MagnoliaDecoder(c).autoDerived[T]
+  inline def deriveConfiguredDecoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+    c: Configuration
+  ): Decoder[T] = new MagnoliaDecoder(c).autoDerived[T]
+
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/semiauto.scala
@@ -8,7 +8,7 @@ import scala.deriving.Mirror
 object semiauto {
   private final val defaultDecoder = new MagnoliaDecoder(Configuration.default)
 
-  inline def deriveDecoder[T](using Mirror.Of[T]): Decoder[T] = defaultDecoder.derived[T]
+  inline def deriveDecoder[T: Mirror.Of: XmlTypeInterpreter]: Decoder[T] = defaultDecoder.derived[T]
   inline def deriveDecoder[T <: AnyVal & Product: XmlTypeInterpreter]: Decoder[T] =
     defaultDecoder.derived[T]
 

--- a/modules/generic/src/main/scala-3/cats/xml/generic/decoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/decoder/semiauto.scala
@@ -5,11 +5,11 @@ import cats.xml.generic.{Configuration, MagnoliaDecoder, XmlTypeInterpreter}
 
 import scala.deriving.Mirror
 
-object auto {
+object semiauto {
   private final val defaultDecoder = new MagnoliaDecoder(Configuration.default)
 
-  inline given deriveDecoder[T](using Mirror.Of[T]): Decoder[T] = defaultDecoder.autoDerived[T]
-  inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Decoder[T] =
-    defaultDecoder.autoDerived[T]
+  inline def deriveDecoder[T](using Mirror.Of[T]): Decoder[T] = defaultDecoder.derived[T]
+  inline def deriveDecoder[T <: AnyVal & Product: XmlTypeInterpreter]: Decoder[T] =
+    defaultDecoder.derived[T]
 
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
@@ -1,0 +1,12 @@
+package cats.xml.generic.encoder
+
+import cats.xml.codec.Encoder
+import cats.xml.generic.{Configuration, MagnoliaEncoder}
+import scala.deriving.Mirror
+
+object auto {
+  private final val foo = new MagnoliaEncoder(Configuration.default)
+
+  inline given deriveEncoder[T](using Mirror.Of[T]): Encoder[T] = foo.autoDerived[T]
+
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
@@ -8,7 +8,7 @@ import scala.deriving.Mirror
 object auto {
   private final val defaultEncoder = new MagnoliaEncoder(Configuration.default)
 
-  inline given deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] =
+  inline given deriveEncoder[T: Mirror.Of: XmlTypeInterpreter]: Encoder[T] =
     defaultEncoder.autoDerived[T]
   inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] =
     defaultEncoder.autoDerived[T]

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
@@ -1,12 +1,14 @@
 package cats.xml.generic.encoder
 
 import cats.xml.codec.Encoder
-import cats.xml.generic.{Configuration, MagnoliaEncoder}
+import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
+
 import scala.deriving.Mirror
 
 object auto {
   private final val foo = new MagnoliaEncoder(Configuration.default)
 
-  inline given deriveEncoder[T](using Mirror.Of[T]): Encoder[T] = foo.autoDerived[T]
+  inline given deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] =
+    foo.autoDerived[T]
 
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/auto.scala
@@ -6,9 +6,11 @@ import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
 import scala.deriving.Mirror
 
 object auto {
-  private final val foo = new MagnoliaEncoder(Configuration.default)
+  private final val defaultEncoder = new MagnoliaEncoder(Configuration.default)
 
   inline given deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] =
-    foo.autoDerived[T]
+    defaultEncoder.autoDerived[T]
+  inline given deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] =
+    defaultEncoder.autoDerived[T]
 
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/configured/auto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/configured/auto.scala
@@ -1,0 +1,16 @@
+package cats.xml.generic.encoder.configured
+
+import cats.xml.codec.Encoder
+import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
+
+import scala.deriving.Mirror
+
+object auto {
+
+  inline given deriveConfiguredEncoder[T: Mirror.Of: XmlTypeInterpreter](using
+    c: Configuration
+  ): Encoder[T] = new MagnoliaEncoder(c).autoDerived[T]
+  inline given deriveConfiguredEncoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+    c: Configuration
+  ): Encoder[T] = new MagnoliaEncoder(c).autoDerived[T]
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/configured/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/configured/semiauto.scala
@@ -1,0 +1,16 @@
+package cats.xml.generic.encoder.configured
+
+import cats.xml.codec.Encoder
+import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
+
+import scala.deriving.Mirror
+
+object semiauto {
+
+  inline def deriveConfiguredEncoder[T: Mirror.Of: XmlTypeInterpreter](using
+    c: Configuration
+  ): Encoder[T] = new MagnoliaEncoder(c).autoDerived[T]
+  inline def deriveConfiguredEncoder[T <: AnyVal & Product: XmlTypeInterpreter](using
+    c: Configuration
+  ): Encoder[T] = new MagnoliaEncoder(c).autoDerived[T]
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
@@ -6,8 +6,10 @@ import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
 import scala.deriving.Mirror
 
 object semiauto {
-  private final val foo = new MagnoliaEncoder(Configuration.default)
+  private final val defaultEncoder = new MagnoliaEncoder(Configuration.default)
 
-  inline def deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] = foo.derived[T]
-  inline def deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] = foo.derived[T]
+  inline def deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] =
+    defaultEncoder.derived[T]
+  inline def deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] =
+    defaultEncoder.derived[T]
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
@@ -1,0 +1,11 @@
+package cats.xml.generic.encoder
+
+import cats.xml.codec.Encoder
+import cats.xml.generic.{Configuration, MagnoliaEncoder}
+import scala.deriving.Mirror
+
+object semiauto {
+  private final val foo = new MagnoliaEncoder(Configuration.default)
+
+  inline def deriveEncoder[T](using Mirror.Of[T]): Encoder[T] = foo.derived[T]
+}

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
@@ -9,5 +9,5 @@ object semiauto {
   private final val foo = new MagnoliaEncoder(Configuration.default)
 
   inline def deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] = foo.derived[T]
-  inline def deriveEncoder[T <: AnyVal: XmlTypeInterpreter]: Encoder[T]           = foo.derived[T]
+  inline def deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] = foo.derived[T]
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
@@ -1,11 +1,13 @@
 package cats.xml.generic.encoder
 
 import cats.xml.codec.Encoder
-import cats.xml.generic.{Configuration, MagnoliaEncoder}
+import cats.xml.generic.{Configuration, MagnoliaEncoder, XmlTypeInterpreter}
+
 import scala.deriving.Mirror
 
 object semiauto {
   private final val foo = new MagnoliaEncoder(Configuration.default)
 
-  inline def deriveEncoder[T](using Mirror.Of[T]): Encoder[T] = foo.derived[T]
+  inline def deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] = foo.derived[T]
+  inline def deriveEncoder[T <: AnyVal: XmlTypeInterpreter]: Encoder[T]           = foo.derived[T]
 }

--- a/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
+++ b/modules/generic/src/main/scala-3/cats/xml/generic/encoder/semiauto.scala
@@ -8,7 +8,7 @@ import scala.deriving.Mirror
 object semiauto {
   private final val defaultEncoder = new MagnoliaEncoder(Configuration.default)
 
-  inline def deriveEncoder[T: XmlTypeInterpreter](using Mirror.Of[T]): Encoder[T] =
+  inline def deriveEncoder[T: Mirror.Of: XmlTypeInterpreter]: Encoder[T] =
     defaultEncoder.derived[T]
   inline def deriveEncoder[T <: AnyVal & Product: XmlTypeInterpreter]: Encoder[T] =
     defaultEncoder.derived[T]

--- a/modules/generic/src/main/scala/cats/xml/generic/XmlTypeInterpreter.scala
+++ b/modules/generic/src/main/scala/cats/xml/generic/XmlTypeInterpreter.scala
@@ -32,6 +32,7 @@ object XmlTypeInterpreter {
     f: (ParamName[T], TypeInfo[?]) => (XmlElemType, Endo[String])
   ): XmlTypeInterpreter[T] =
     new XmlTypeInterpreter[T] {
+      override def toString: String = s"XmlTypeInterpreter[\n$classFieldsInfo\n$classInfoExtractor]"
 
       val classFieldsInfo: Map[ParamName[T], TypeInfo[?]] = TypeInfo[T].accessorsInfo
       val classInfoExtractor: ParamNameExtractor[T]       = ParamNameExtractor.of[T]

--- a/modules/generic/src/main/scala/cats/xml/generic/XmlTypeInterpreter.scala
+++ b/modules/generic/src/main/scala/cats/xml/generic/XmlTypeInterpreter.scala
@@ -104,7 +104,7 @@ object XmlTypeInterpreter {
         tpeInfo.isString
           || tpeInfo.isPrimitive
           || tpeInfo.isPrimitiveWrapper
-          || tpeInfo.isValueClass
+          || (tpeInfo.isValueClass && !tpeInfo.isNonPrimitiveValueClass)
           || tpeInfo.isOptionOfAnyPrimitiveOrString
   ): XmlTypeInterpreter[T] =
     XmlTypeInterpreter.of[T] { case (paramName, tpeInfo) =>

--- a/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
@@ -4,8 +4,8 @@ import cats.xml.codec.Decoder
 
 object Samples {
 
-  import cats.xml.generic.MagnoliaDecoder.given
-  import cats.xml.generic.MagnoliaDecoder.*
+//  import cats.xml.generic.MagnoliaDecoder.given
+//  import cats.xml.generic.MagnoliaDecoder.*
 
   case class ValueClass(value: String) extends AnyVal derives DerivedDecoder
   case class Bar(field1: String, field2: BigDecimal) derives DerivedDecoder
@@ -17,4 +17,11 @@ object Samples {
     missingField: Option[String],
     missingNode: Option[Bar]
   ) derives DerivedDecoder
+
+  sealed trait Vehicle {
+    val wheelCount: Int
+  }
+  case class Car(wheelCount: Int) extends Vehicle
+  case class Bike(wheelCount: Int) extends Vehicle
+  case class Motorcycle(wheelCount: Int) extends Vehicle
 }

--- a/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
@@ -7,8 +7,6 @@ object Samples {
   import cats.xml.generic.MagnoliaDecoder.given
   import cats.xml.generic.MagnoliaDecoder.*
 
-  // TODO: Derive this somehow
-  private implicit def wrapValueClass: WrapAnyVal[ValueClass, String] = WrapAnyVal(ValueClass.apply)
   case class ValueClass(value: String) extends AnyVal derives DerivedDecoder
   case class Bar(field1: String, field2: BigDecimal) derives DerivedDecoder
 

--- a/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
@@ -4,15 +4,15 @@ import cats.xml.codec.Decoder
 
 object Samples {
 
-//  import cats.xml.generic.MagnoliaDecoder.given
-//  import cats.xml.generic.MagnoliaDecoder.*
-
   case class ValueClass(value: String) extends AnyVal derives DerivedDecoder
+  case class InsideValueClass(v: String) derives DerivedDecoder
+  case class ValueClass2(value: InsideValueClass) extends AnyVal derives DerivedDecoder
   case class Bar(field1: String, field2: BigDecimal) derives DerivedDecoder
 
   case class Foo(
     primitiveField: Double = 666d,
     valueClass: ValueClass,
+    valueClass2: ValueClass2,
     bar: Bar,
     missingField: Option[String],
     missingNode: Option[Bar]

--- a/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
@@ -1,20 +1,20 @@
-//package cats.xml.generic
-//
-//import cats.xml.codec.Decoder
-//
-//object Samples {
-//
-//  import cats.xml.generic.MagnoliaDecoder.given
-//  import cats.xml.generic.MagnoliaDecoder.*
-//
-//  case class ValueClass(value: String) extends AnyVal derives Decoder
-//  case class Bar(field1: String, field2: BigDecimal) derives Decoder
-//
-//  case class Foo(
-//    primitiveField: Double = 666d,
-//    valueClass: ValueClass,
-//    bar: Bar,
-//    missingField: Option[String],
-//    missingNode: Option[Bar]
-//  ) derives Decoder
-//}
+package cats.xml.generic
+
+import cats.xml.codec.Decoder
+
+object Samples {
+
+  import cats.xml.generic.MagnoliaDecoder.given
+  import cats.xml.generic.MagnoliaDecoder.*
+
+  case class ValueClass(value: String) /*extends AnyVal*/ derives Decoder
+  case class Bar(field1: String, field2: BigDecimal) derives Decoder
+
+  case class Foo(
+    primitiveField: Double = 666d,
+    valueClass: ValueClass,
+    bar: Bar,
+    missingField: Option[String],
+    missingNode: Option[Bar]
+  ) derives Decoder
+}

--- a/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/Samples.scala
@@ -7,8 +7,10 @@ object Samples {
   import cats.xml.generic.MagnoliaDecoder.given
   import cats.xml.generic.MagnoliaDecoder.*
 
-  case class ValueClass(value: String) /*extends AnyVal*/ derives Decoder
-  case class Bar(field1: String, field2: BigDecimal) derives Decoder
+  // TODO: Derive this somehow
+  private implicit def wrapValueClass: WrapAnyVal[ValueClass, String] = WrapAnyVal(ValueClass.apply)
+  case class ValueClass(value: String) extends AnyVal derives DerivedDecoder
+  case class Bar(field1: String, field2: BigDecimal) derives DerivedDecoder
 
   case class Foo(
     primitiveField: Double = 666d,
@@ -16,5 +18,5 @@ object Samples {
     bar: Bar,
     missingField: Option[String],
     missingNode: Option[Bar]
-  ) derives Decoder
+  ) derives DerivedDecoder
 }

--- a/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
@@ -18,9 +18,6 @@ class DecoderSuite extends munit.FunSuite {
         .overrideType(
           _.param(_.valueClass) -> XmlElemType.Attribute
         )
-//
-//    given Decoder[Bar] = deriveDecoder[Bar]
-//    given Decoder[Foo] = deriveDecoder[Foo]
 
     assertEquals(
       obtained = XmlNode("foo")

--- a/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
@@ -30,13 +30,15 @@ class DecoderSuite extends munit.FunSuite {
             .withAttrs(
               "field1" := "BHO",
               "field2" := BigDecimal(100)
-            )
+            ),
+          XmlNode("valueClass2").withAttrs("v" := "OK!")
         )
         .as[Foo],
       expected = Valid(
         Foo(
           primitiveField = 1d,
           valueClass     = ValueClass("TEST"),
+          valueClass2    = ValueClass2(InsideValueClass("OK!")),
           bar            = Bar("BHO", BigDecimal(100)),
           missingField   = None,
           missingNode    = None

--- a/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
@@ -1,50 +1,50 @@
-//package cats.xml.generic.decoder
-//
-//import cats.data.Validated.Valid
-//import cats.xml.XmlNode
-//import cats.xml.codec.Decoder
-//import cats.xml.generic.{Samples, XmlElemType, XmlTypeInterpreter}
-//
-//class DecoderSuite extends munit.FunSuite {
-//
-//  import cats.xml.syntax.given
-//  import Samples.*
-//
-//  test("auto") {
-//
-//    given XmlTypeInterpreter[Foo] =
-//      XmlTypeInterpreter
-//        .default[Foo]
+package cats.xml.generic.decoder
+
+import cats.data.Validated.Valid
+import cats.xml.XmlNode
+import cats.xml.codec.Decoder
+import cats.xml.generic.{Samples, XmlElemType, XmlTypeInterpreter}
+
+class DecoderSuite extends munit.FunSuite {
+
+  import cats.xml.syntax.given
+  import Samples.*
+
+  test("auto") {
+
+    given XmlTypeInterpreter[Foo] =
+      XmlTypeInterpreter
+        .default[Foo]
 //        .overrideType(
 //          _.param(_.valueClass) -> XmlElemType.Attribute
 //        )
 //
-////    given Decoder[Bar] = deriveDecoder[Bar]
-////    given Decoder[Foo] = deriveDecoder[Foo]
-//
-//    assertEquals(
-//      obtained = XmlNode("foo")
-//        .withAttrs(
-//          "primitiveField" := 1d,
-//          "valueClass"     := "TEST"
-//        )
-//        .withChildren(
-//          XmlNode("bar")
-//            .withAttrs(
-//              "field1" := "BHO",
-//              "field2" := BigDecimal(100)
-//            )
-//        )
-//        .as[Foo],
-//      expected = Valid(
-//        Foo(
-//          primitiveField = 1d,
-//          valueClass     = ValueClass("TEST"),
-//          bar            = Bar("BHO", BigDecimal(100)),
-//          missingField   = None,
-//          missingNode    = None
-//        )
-//      )
-//    )
-//  }
-//}
+//    given Decoder[Bar] = deriveDecoder[Bar]
+//    given Decoder[Foo] = deriveDecoder[Foo]
+
+    assertEquals(
+      obtained = XmlNode("foo")
+        .withAttrs(
+          "primitiveField" := 1d,
+          "valueClass"     := "TEST"
+        )
+        .withChildren(
+          XmlNode("bar")
+            .withAttrs(
+              "field1" := "BHO",
+              "field2" := BigDecimal(100)
+            )
+        )
+        .as[Foo],
+      expected = Valid(
+        Foo(
+          primitiveField = 1d,
+          valueClass     = ValueClass("TEST"),
+          bar            = Bar("BHO", BigDecimal(100)),
+          missingField   = None,
+          missingNode    = None
+        )
+      )
+    )
+  }
+}

--- a/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/decoder/DecoderSuite.scala
@@ -15,9 +15,9 @@ class DecoderSuite extends munit.FunSuite {
     given XmlTypeInterpreter[Foo] =
       XmlTypeInterpreter
         .default[Foo]
-//        .overrideType(
-//          _.param(_.valueClass) -> XmlElemType.Attribute
-//        )
+        .overrideType(
+          _.param(_.valueClass) -> XmlElemType.Attribute
+        )
 //
 //    given Decoder[Bar] = deriveDecoder[Bar]
 //    given Decoder[Foo] = deriveDecoder[Foo]

--- a/modules/generic/src/test/scala-3/cats/xml/generic/decoder/configured/ConfiguredDecoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/decoder/configured/ConfiguredDecoderSuite.scala
@@ -1,0 +1,93 @@
+package cats.xml.generic.decoder.configured
+
+import cats.data.Validated.Valid
+import cats.xml.XmlNode
+import cats.xml.codec.Decoder
+import cats.xml.generic.Configuration
+
+class ConfiguredDecoderSuite extends munit.FunSuite {
+
+  import cats.xml.syntax.*
+  import cats.xml.generic.Samples.*
+
+  // --------------------- AUTO ---------------------
+  test("auto configured with useDefaults") {
+
+    case class Foo(
+      a: String,
+      b: String = "DEFAULT"
+    )
+
+    import cats.xml.generic.decoder.configured.auto.{given, *}
+    implicit val config: Configuration = Configuration.default.withDefaults
+
+    assertEquals(
+      obtained = XmlNode("Foo")
+        .withAttrs(
+          "a" := "TEST"
+        )
+        .as[Foo],
+      expected = Valid(Foo("TEST", "DEFAULT"))
+    )
+  }
+
+  test("auto configured with ADT with discriminator attr") {
+
+    import cats.xml.generic.decoder.configured.auto.{given, *}
+
+    implicit val config: Configuration = Configuration.default
+      .withDiscriminatorAttrKey("kind")
+
+    assertEquals(
+      obtained = XmlNode("MyVehicle")
+        .withAttrs(
+          "kind"       := "Bike",
+          "wheelCount" := 2
+        )
+        .as[Vehicle],
+      expected = Valid(Bike(2))
+    )
+  }
+
+  // --------------------- SEMIAUTO ---------------------
+  test("semiauto configured with useDefaults") {
+
+    case class Foo(
+      a: String,
+      b: String = "DEFAULT"
+    )
+
+    import cats.xml.generic.decoder.configured.semiauto.*
+    implicit val config: Configuration    = Configuration.default.withDefaults
+    implicit val decoderFoo: Decoder[Foo] = deriveConfiguredDecoder[Foo]
+
+    assertEquals(
+      obtained = XmlNode("Foo")
+        .withAttrs(
+          "a" := "TEST"
+        )
+        .as[Foo],
+      expected = Valid(Foo("TEST", "DEFAULT"))
+    )
+  }
+
+  test("semiauto configured with ADT with discriminator attr") {
+
+    import cats.xml.generic.decoder.configured.semiauto.*
+
+    implicit val config: Configuration = Configuration.default
+      .withDiscriminatorAttrKey("kind")
+
+    implicit val decoder: Decoder[Vehicle] = deriveConfiguredDecoder[Vehicle]
+
+    assertEquals(
+      obtained = XmlNode("MyVehicle")
+        .withAttrs(
+          "kind"       := "Bike",
+          "wheelCount" := 2
+        )
+        .as[Vehicle],
+      expected = Valid(Bike(2))
+    )
+  }
+}

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -10,38 +10,38 @@ class EncoderSuite extends munit.FunSuite {
   import cats.xml.syntax.*
   import cats.xml.generic.Samples.*
 
-//  test("auto") {
-//
-//    import cats.xml.generic.encoder.auto.*
-//
-//    assertEquals(
-//      obtained = Foo(
-//        primitiveField = 1d,
-//        valueClass     = ValueClass("TEST"),
-//        bar            = Bar("BHO", BigDecimal(100)),
-//        missingField   = None,
-//        missingNode    = None
-//      ).toXml,
-//      expected = XmlNode("Foo")
-//        .withAttrs(
-//          "primitiveField" := 1d,
-//          "valueClass"     := "TEST"
-//        )
-//        .withChildren(
-//          XmlNode("Bar")
-//            .withAttrs(
-//              "field1" := "BHO",
-//              "field2" := BigDecimal(100)
-//            )
-//        )
-//    )
-//  }
+  test("auto") {
+
+    import cats.xml.generic.encoder.auto.*
+    import cats.xml.generic.encoder.auto.given
+
+    assertEquals(
+      obtained = Foo(
+        primitiveField = 1d,
+        valueClass     = ValueClass("TEST"),
+        bar            = Bar("BHO", BigDecimal(100)),
+        missingField   = None,
+        missingNode    = None
+      ).toXml,
+      expected = XmlNode("Foo")
+        .withAttrs(
+          "primitiveField" := 1d,
+          "valueClass"     := "TEST"
+        )
+        .withChildren(
+          XmlNode("Bar")
+            .withAttrs(
+              "field1" := "BHO",
+              "field2" := BigDecimal(100)
+            )
+        )
+    )
+  }
 
   test("semiauto") {
 
     import cats.xml.generic.encoder.semiauto.*
 
-//    println(s"The type info is ${TypeInfo[Foo]}")
     implicit val typeInterpreterValueClass: XmlTypeInterpreter[ValueClass] =
       XmlTypeInterpreter.default[ValueClass]
     implicit val typeInterpreterBar: XmlTypeInterpreter[Bar] = XmlTypeInterpreter.default[Bar]

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -2,57 +2,17 @@ package cats.xml.generic.encoder
 
 import cats.xml.XmlNode
 import cats.xml.codec.Encoder
-import cats.xml.generic.{XmlElemType, XmlTypeInterpreter}
+import cats.xml.generic.{UnwrapAnyVal, XmlElemType, XmlTypeInterpreter}
+import cats.xml.utils.generic.TypeInfo
 
 class EncoderSuite extends munit.FunSuite {
 
   import cats.xml.syntax.*
   import cats.xml.generic.Samples.*
 
-  test("auto") {
-
-    import cats.xml.generic.encoder.semiauto.*
-    given Encoder[ValueClass] = deriveEncoder[ValueClass]
-    given Encoder[Bar]        = deriveEncoder[Bar]
-    given Encoder[Foo]        = deriveEncoder[Foo]
-
-    assertEquals(
-      obtained = Foo(
-        primitiveField = 1d,
-        valueClass     = ValueClass("TEST"),
-        bar            = Bar("BHO", BigDecimal(100)),
-        missingField   = None,
-        missingNode    = None
-      ).toXml,
-      expected = XmlNode("Foo")
-        .withAttrs(
-          "primitiveField" := 1d,
-          "valueClass"     := "TEST"
-        )
-        .withChildren(
-          XmlNode("Bar")
-            .withAttrs(
-              "field1" := "BHO",
-              "field2" := BigDecimal(100)
-            )
-        )
-    )
-  }
-
-//  test("semiauto") {
+//  test("auto") {
 //
-//    import cats.xml.generic.encoder.semiauto.*
-//
-//    implicit val typeInterpreterFoo: XmlTypeInterpreter[Foo] =
-//      XmlTypeInterpreter
-//        .default[Foo]
-//        .overrideType(
-//          _.param(_.valueClass) -> XmlElemType.Attribute
-//        )
-//
-//    implicit val encoderValueClass: Encoder[ValueClass] = deriveEncoder[ValueClass]
-//    implicit val encoderBar: Encoder[Bar]               = deriveEncoder[Bar]
-//    implicit val encoderFoo: Encoder[Foo]               = deriveEncoder[Foo]
+//    import cats.xml.generic.encoder.auto.*
 //
 //    assertEquals(
 //      obtained = Foo(
@@ -76,5 +36,51 @@ class EncoderSuite extends munit.FunSuite {
 //        )
 //    )
 //  }
+
+  test("semiauto") {
+
+    import cats.xml.generic.encoder.semiauto.*
+
+//    println(s"The type info is ${TypeInfo[Foo]}")
+    implicit val typeInterpreterValueClass: XmlTypeInterpreter[ValueClass] =
+      XmlTypeInterpreter.default[ValueClass]
+    implicit val typeInterpreterBar: XmlTypeInterpreter[Bar] = XmlTypeInterpreter.default[Bar]
+    implicit val typeInterpreterFoo: XmlTypeInterpreter[Foo] =
+      XmlTypeInterpreter
+        .default[Foo]
+        .overrideType(
+          _.param(_.valueClass) -> XmlElemType.Attribute
+        )
+
+    // TODO: Derive this somehow
+    implicit val anyValSupport: UnwrapAnyVal[ValueClass, String] = UnwrapAnyVal(_.value)
+    implicit val encoderValueClass: Encoder[ValueClass]          = deriveEncoder[ValueClass]
+    implicit val encoderBar: Encoder[Bar]                        = deriveEncoder[Bar]
+    implicit val encoderFoo: Encoder[Foo]                        = deriveEncoder[Foo]
+    println("-- finished deriving --")
+    val xml = Foo(
+      primitiveField = 1d,
+      valueClass     = ValueClass("TEST"),
+      bar            = Bar("BHO", BigDecimal(100)),
+      missingField   = None,
+      missingNode    = None
+    ).toXml
+    println(s"xm= ${xml}")
+    assertEquals(
+      obtained = xml,
+      expected = XmlNode("Foo")
+        .withAttrs(
+          "primitiveField" := 1d,
+          "valueClass"     := "TEST"
+        )
+        .withChildren(
+          XmlNode("Bar")
+            .withAttrs(
+              "field1" := "BHO",
+              "field2" := BigDecimal(100)
+            )
+        )
+    )
+  }
 
 }

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -2,7 +2,7 @@ package cats.xml.generic.encoder
 
 import cats.xml.XmlNode
 import cats.xml.codec.Encoder
-import cats.xml.generic.{UnwrapAnyVal, XmlElemType, XmlTypeInterpreter}
+import cats.xml.generic.{XmlElemType, XmlTypeInterpreter}
 import cats.xml.utils.generic.TypeInfo
 
 class EncoderSuite extends munit.FunSuite {
@@ -52,17 +52,9 @@ class EncoderSuite extends munit.FunSuite {
           _.param(_.valueClass) -> XmlElemType.Attribute
         )
 
-      // TODO: Derive this somehow
-//      val x = cats.xml.generic.FullSupp.apply[cats.xml.generic.Samples.ValueClass](
-//        cats.xml.generic.WrapAndSerde.apply[cats.xml.generic.Samples.ValueClass, java.lang.String](
-//          ValueClass.this
-//        )(this.noMirrorDerived[scala.Predef.String])
-//      )
-//    val x = ValueClass.this("asd")
-    implicit val anyValSupport: UnwrapAnyVal[ValueClass, String] = UnwrapAnyVal(_.value)
-    implicit val encoderValueClass: Encoder[ValueClass]          = deriveEncoder[ValueClass]
-    implicit val encoderBar: Encoder[Bar]                        = deriveEncoder[Bar]
-    implicit val encoderFoo: Encoder[Foo]                        = deriveEncoder[Foo]
+    implicit val encoderValueClass: Encoder[ValueClass] = deriveEncoder[ValueClass]
+    implicit val encoderBar: Encoder[Bar]               = deriveEncoder[Bar]
+    implicit val encoderFoo: Encoder[Foo]               = deriveEncoder[Foo]
     val xml = Foo(
       primitiveField = 1d,
       valueClass     = ValueClass("TEST"),

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -3,12 +3,11 @@ package cats.xml.generic.encoder
 import cats.xml.XmlNode
 import cats.xml.codec.Encoder
 import cats.xml.generic.{XmlElemType, XmlTypeInterpreter}
+import cats.xml.generic.Samples.*
+import cats.xml.syntax.*
 import cats.xml.utils.generic.TypeInfo
 
 class EncoderSuite extends munit.FunSuite {
-
-  import cats.xml.syntax.*
-  import cats.xml.generic.Samples.*
 
   test("auto") {
 
@@ -19,6 +18,7 @@ class EncoderSuite extends munit.FunSuite {
       obtained = Foo(
         primitiveField = 1d,
         valueClass     = ValueClass("TEST"),
+        valueClass2    = ValueClass2(InsideValueClass("OK!")),
         bar            = Bar("BHO", BigDecimal(100)),
         missingField   = None,
         missingNode    = None
@@ -29,6 +29,7 @@ class EncoderSuite extends munit.FunSuite {
           "valueClass"     := "TEST"
         )
         .withChildren(
+          XmlNode("InsideValueClass").withAttrs("v" := "OK!"),
           XmlNode("Bar")
             .withAttrs(
               "field1" := "BHO",
@@ -53,11 +54,15 @@ class EncoderSuite extends munit.FunSuite {
         )
 
     implicit val encoderValueClass: Encoder[ValueClass] = deriveEncoder[ValueClass]
-    implicit val encoderBar: Encoder[Bar]               = deriveEncoder[Bar]
-    implicit val encoderFoo: Encoder[Foo]               = deriveEncoder[Foo]
+    implicit val encoderInsideValueClass: Encoder[InsideValueClass] =
+      deriveEncoder[InsideValueClass]
+    implicit val encoderValueClass2: Encoder[ValueClass2] = deriveEncoder[ValueClass2]
+    implicit val encoderBar: Encoder[Bar]                 = deriveEncoder[Bar]
+    implicit val encoderFoo: Encoder[Foo]                 = deriveEncoder[Foo]
     val xml = Foo(
       primitiveField = 1d,
       valueClass     = ValueClass("TEST"),
+      valueClass2    = ValueClass2(InsideValueClass("OK!")),
       bar            = Bar("BHO", BigDecimal(100)),
       missingField   = None,
       missingNode    = None
@@ -70,6 +75,7 @@ class EncoderSuite extends munit.FunSuite {
           "valueClass"     := "TEST"
         )
         .withChildren(
+          XmlNode("InsideValueClass").withAttrs("v" := "OK!"),
           XmlNode("Bar")
             .withAttrs(
               "field1" := "BHO",

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -52,12 +52,17 @@ class EncoderSuite extends munit.FunSuite {
           _.param(_.valueClass) -> XmlElemType.Attribute
         )
 
-    // TODO: Derive this somehow
+      // TODO: Derive this somehow
+//      val x = cats.xml.generic.FullSupp.apply[cats.xml.generic.Samples.ValueClass](
+//        cats.xml.generic.WrapAndSerde.apply[cats.xml.generic.Samples.ValueClass, java.lang.String](
+//          ValueClass.this
+//        )(this.noMirrorDerived[scala.Predef.String])
+//      )
+//    val x = ValueClass.this("asd")
     implicit val anyValSupport: UnwrapAnyVal[ValueClass, String] = UnwrapAnyVal(_.value)
     implicit val encoderValueClass: Encoder[ValueClass]          = deriveEncoder[ValueClass]
     implicit val encoderBar: Encoder[Bar]                        = deriveEncoder[Bar]
     implicit val encoderFoo: Encoder[Foo]                        = deriveEncoder[Foo]
-    println("-- finished deriving --")
     val xml = Foo(
       primitiveField = 1d,
       valueClass     = ValueClass("TEST"),
@@ -65,7 +70,6 @@ class EncoderSuite extends munit.FunSuite {
       missingField   = None,
       missingNode    = None
     ).toXml
-    println(s"xm= ${xml}")
     assertEquals(
       obtained = xml,
       expected = XmlNode("Foo")

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/EncoderSuite.scala
@@ -1,0 +1,80 @@
+package cats.xml.generic.encoder
+
+import cats.xml.XmlNode
+import cats.xml.codec.Encoder
+import cats.xml.generic.{XmlElemType, XmlTypeInterpreter}
+
+class EncoderSuite extends munit.FunSuite {
+
+  import cats.xml.syntax.*
+  import cats.xml.generic.Samples.*
+
+  test("auto") {
+
+    import cats.xml.generic.encoder.semiauto.*
+    given Encoder[ValueClass] = deriveEncoder[ValueClass]
+    given Encoder[Bar]        = deriveEncoder[Bar]
+    given Encoder[Foo]        = deriveEncoder[Foo]
+
+    assertEquals(
+      obtained = Foo(
+        primitiveField = 1d,
+        valueClass     = ValueClass("TEST"),
+        bar            = Bar("BHO", BigDecimal(100)),
+        missingField   = None,
+        missingNode    = None
+      ).toXml,
+      expected = XmlNode("Foo")
+        .withAttrs(
+          "primitiveField" := 1d,
+          "valueClass"     := "TEST"
+        )
+        .withChildren(
+          XmlNode("Bar")
+            .withAttrs(
+              "field1" := "BHO",
+              "field2" := BigDecimal(100)
+            )
+        )
+    )
+  }
+
+//  test("semiauto") {
+//
+//    import cats.xml.generic.encoder.semiauto.*
+//
+//    implicit val typeInterpreterFoo: XmlTypeInterpreter[Foo] =
+//      XmlTypeInterpreter
+//        .default[Foo]
+//        .overrideType(
+//          _.param(_.valueClass) -> XmlElemType.Attribute
+//        )
+//
+//    implicit val encoderValueClass: Encoder[ValueClass] = deriveEncoder[ValueClass]
+//    implicit val encoderBar: Encoder[Bar]               = deriveEncoder[Bar]
+//    implicit val encoderFoo: Encoder[Foo]               = deriveEncoder[Foo]
+//
+//    assertEquals(
+//      obtained = Foo(
+//        primitiveField = 1d,
+//        valueClass     = ValueClass("TEST"),
+//        bar            = Bar("BHO", BigDecimal(100)),
+//        missingField   = None,
+//        missingNode    = None
+//      ).toXml,
+//      expected = XmlNode("Foo")
+//        .withAttrs(
+//          "primitiveField" := 1d,
+//          "valueClass"     := "TEST"
+//        )
+//        .withChildren(
+//          XmlNode("Bar")
+//            .withAttrs(
+//              "field1" := "BHO",
+//              "field2" := BigDecimal(100)
+//            )
+//        )
+//    )
+//  }
+
+}

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/configured/ConfiguredEncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/configured/ConfiguredEncoderSuite.scala
@@ -1,0 +1,87 @@
+package cats.xml.generic.encoder.configured
+
+import cats.xml.XmlNode
+import cats.xml.codec.Encoder
+import cats.xml.generic.{Configuration, XmlTypeInterpreter}
+import cats.xml.utils.generic.ParamName
+
+class ConfiguredEncoderSuite extends munit.FunSuite {
+
+  import cats.xml.generic.Samples.*
+  import cats.xml.syntax.*
+
+  // --------------------- AUTO ---------------------
+  test("auto configured with ADT with discriminator attr") {
+
+    import cats.xml.generic.encoder.configured.auto.{given, *}
+
+    implicit val config: Configuration = Configuration.default
+      .withDiscriminatorAttrKey("kind")
+
+    assertEquals(
+      obtained = Bike(2).toXmlWiden[Vehicle],
+      expected = XmlNode("Vehicle")
+        .withAttrs(
+          "kind"       := "Bike",
+          "wheelCount" := 2
+        )
+    )
+  }
+
+  // --------------------- SEMIAUTO ---------------------
+  test("semiauto configured with ADT with discriminator attr") {
+
+    import cats.xml.generic.encoder.configured.semiauto.{given, *}
+
+    implicit val config: Configuration = Configuration.default
+      .withDiscriminatorAttrKey("kind")
+
+    implicit val encoderVehicle: Encoder[Vehicle] =
+      deriveConfiguredEncoder[Vehicle]
+
+    assertEquals(
+      obtained = Bike(2).toXmlWiden[Vehicle],
+      expected = XmlNode("Vehicle")
+        .withAttrs(
+          "kind"       := "Bike",
+          "wheelCount" := 2
+        )
+    )
+  }
+
+  test("semiauto configured with useLabelsForNodes") {
+
+    import cats.xml.generic.encoder.configured.semiauto.{given, *}
+
+    implicit val config: Configuration = Configuration.default
+      .withUseLabelsForNodes(true)
+    implicit val fooXmlTypeInterpreter: XmlTypeInterpreter[Bar] =
+      XmlTypeInterpreter.auto[Bar]((_, _) => false, (_, _) => false)
+    implicit val barXmlTypeInterpreter: XmlTypeInterpreter[Foo] =
+      XmlTypeInterpreter.auto[Foo]((_, _) => false, (_, _) => false)
+
+    implicit val encoderValueClass: Encoder[ValueClass] = deriveConfiguredEncoder[ValueClass]
+    implicit val encoderBar: Encoder[Bar]               = deriveConfiguredEncoder[Bar]
+    implicit val encoderFoo: Encoder[Foo]               = deriveConfiguredEncoder[Foo]
+
+    assertEquals(
+      obtained = Foo(
+        primitiveField = 666d,
+        valueClass     = ValueClass("hi"),
+        bar            = Bar("f1", BigDecimal(12.34)),
+        missingField   = None,
+        missingNode    = None
+      ).toXmlWiden[Foo],
+      expected = XmlNode("Foo")
+        .withChildren(
+          XmlNode("primitiveField").withText(666d),
+          XmlNode("valueClass").withText("hi"),
+          XmlNode("bar")
+            .withChildren(
+              XmlNode("field1").withText("f1"),
+              XmlNode("field2").withText(BigDecimal(12.34))
+            )
+        )
+    )
+  }
+}

--- a/modules/generic/src/test/scala-3/cats/xml/generic/encoder/configured/ConfiguredEncoderSuite.scala
+++ b/modules/generic/src/test/scala-3/cats/xml/generic/encoder/configured/ConfiguredEncoderSuite.scala
@@ -57,17 +57,23 @@ class ConfiguredEncoderSuite extends munit.FunSuite {
       .withUseLabelsForNodes(true)
     implicit val fooXmlTypeInterpreter: XmlTypeInterpreter[Bar] =
       XmlTypeInterpreter.auto[Bar]((_, _) => false, (_, _) => false)
+    implicit val insideValueClassXmlTypeInterpreter: XmlTypeInterpreter[InsideValueClass] =
+      XmlTypeInterpreter.auto[InsideValueClass]((_, _) => false, (_, _) => false)
     implicit val barXmlTypeInterpreter: XmlTypeInterpreter[Foo] =
       XmlTypeInterpreter.auto[Foo]((_, _) => false, (_, _) => false)
 
     implicit val encoderValueClass: Encoder[ValueClass] = deriveConfiguredEncoder[ValueClass]
-    implicit val encoderBar: Encoder[Bar]               = deriveConfiguredEncoder[Bar]
-    implicit val encoderFoo: Encoder[Foo]               = deriveConfiguredEncoder[Foo]
+    implicit val encoderInsideValueClass: Encoder[InsideValueClass] =
+      deriveConfiguredEncoder[InsideValueClass]
+    implicit val encoderValueClass2: Encoder[ValueClass2] = deriveConfiguredEncoder[ValueClass2]
+    implicit val encoderBar: Encoder[Bar]                 = deriveConfiguredEncoder[Bar]
+    implicit val encoderFoo: Encoder[Foo]                 = deriveConfiguredEncoder[Foo]
 
     assertEquals(
       obtained = Foo(
         primitiveField = 666d,
         valueClass     = ValueClass("hi"),
+        valueClass2    = ValueClass2(InsideValueClass("OK!")),
         bar            = Bar("f1", BigDecimal(12.34)),
         missingField   = None,
         missingNode    = None
@@ -76,6 +82,8 @@ class ConfiguredEncoderSuite extends munit.FunSuite {
         .withChildren(
           XmlNode("primitiveField").withText(666d),
           XmlNode("valueClass").withText("hi"),
+          XmlNode("valueClass2")
+            .withChildren(XmlNode("v").withText("OK!")),
           XmlNode("bar")
             .withChildren(
               XmlNode("field1").withText("f1"),


### PR DESCRIPTION
Passes tests and supports the `derives` syntax.

Also fixes some bugs when handling 'AnyVal' wrappers of non-primitive types.

AnyVal support was insanely tricky and I feel like I must've completely missed some easier way to achieve the same thing. OTOH IDE support for scala 3 macros is so much better than it used to be, so that's nice.

Some of this code feels like it belongs in magnolia, so I've opened a pr there to see if it can be included upstream; however that's probably still a fair way away from landing, and the local re-implementations should be fine in the meantime...